### PR TITLE
PR作成スクリプト(`pr`)の実装と関連スクリプトの修正

### DIFF
--- a/bin/git_llm_commit
+++ b/bin/git_llm_commit
@@ -25,7 +25,7 @@ trap_exit() {
 }
 
 cat_prompt() {
-  git diff --minimal --cached |
+  git diff --minimal --cached -- ':!*/package-lock.json' |
     prp -ne gen-git-commit-message.md
 }
 

--- a/bin/gpr
+++ b/bin/gpr
@@ -23,14 +23,16 @@ is_inside_repo() {
 main() {
   ! is_inside_repo && echo "Not in repository." 1>&2 && exit 1
   if [[ -n $target ]]; then
-    cd $target
+    cd "$target" || exit
   fi
-  local modified=$(git status -s)
+  local modified
+  modified=$(git status -s)
   local stash=0
   # local stash_msg=""
   if [[ $modified != "" ]]; then
     # local shuld_stash=$(echo "$modified" | grep -v '??' | wc -l)
-    local shuld_stash=$(echo "$modified" | grep -c -v '??')
+    local shuld_stash
+    shuld_stash=$(echo "$modified" | grep -c -v '??')
     if [[ $shuld_stash -gt 0 ]]; then
       stash=1
       # stash_msg="(with_stash)"
@@ -55,7 +57,7 @@ main() {
     echo "$modified"
   fi
   if [[ -n $target ]]; then
-    cd - >/dev/null 2>&1
+    cd - >/dev/null 2>&1 || exit
   fi
 }
 main "$@"

--- a/bin/lib/setup/trans/manjaro
+++ b/bin/lib/setup/trans/manjaro
@@ -22,7 +22,7 @@ load_update_arg_apps() {
   # cargo order bug?
   # shellcheck disable=SC2034
   read -r -a args < <(
-    echo "$(default_apps) xclip snap fcitx5-mozc hackgen udev-gothic gnome-font-viewer code font wezterm"
+    echo "$(default_apps) xclip snap fcitx5-mozc hackgen udev-gothic gnome-font-viewer code font wezterm kdeconnect"
   )
 }
 

--- a/bin/llm
+++ b/bin/llm
@@ -1,5 +1,6 @@
 #!/usr/bin/env -S bash -e
 
+readonly model=gemini-2.5-flash-preview-04-17
 readonly depends=(gemini-cli)
 has() { command -v "${1}" >&/dev/null; }
 hass() { for arg in "$@"; do has "$arg" || error "==> No $arg command exist."; done; }
@@ -24,6 +25,6 @@ main() {
   if [[ $# -eq 0 && ! -p /dev/stdin ]]; then
     error "==> No input data."
   fi
-  fire "$@" | command gemini-cli prompt -
+  fire "$@" | command gemini-cli prompt --model $model -
 }
 main "$@"

--- a/bin/pr
+++ b/bin/pr
@@ -1,0 +1,100 @@
+#!/usr/bin/env -S bash -e
+
+readonly depends=(gh curl fzf jq llm)
+
+has() { command -v "${1}" >&/dev/null; }
+hass() { for arg in "$@"; do has "$arg" || error "==> No $arg command exist."; done; }
+_ink() { cat - | if has ink; then ink "$@"; else cat -; fi; }
+# shellcheck disable=SC2145
+_log() { echo "$(date +"%Y-%m-%d %H:%M:%S") ${@:2}" | _ink "$1"; }
+log() { _log white "$*"; }
+info() { _log cyan "$*"; }
+warn() { _log yellow "$*"; }
+error() { _log red "$*" && exit 1; }
+
+end() {
+  rm -rf /tmp/pr
+}
+
+find_target_branch() {
+  remote_branches=$(git ls-remote --heads origin)
+  branches=(develop main master)
+  for b in "${branches[@]}"; do
+    if echo -e "$remote_branches" | grep -q "refs/heads/$b"; then
+      echo "origin/$b"
+      return
+    fi
+  done
+}
+
+cat_issue() {
+  cat <<EOF
+
+## 関連Issue
+
+- 関連Issue: $issue
+
+EOF
+}
+
+cat_commit_list() {
+  cat <<EOF
+
+## コミット一覧
+
+$(sed -e 's/^/- /' /tmp/pr/commit_list)
+
+EOF
+}
+
+main() {
+  local issue=$1
+  hass "${depends[@]}"
+
+  if git branch --show-current | grep -q 'develop'; then
+    error "==> You are on develop branch."
+  fi
+
+  # Fetch the latest changes from the remote repository
+  info "==> Git fetching.."
+  git fetch origin
+  info "==> Finding target branch.."
+  target_branch=$(find_target_branch)
+
+  mkdir -p /tmp/pr
+  # trap end 0 1 2 3 15
+
+  info "==> Creating diff.."
+  git diff "$target_branch"...HEAD >/tmp/pr/diff
+  info "==> Creating commit_list.."
+  git log --oneline "$target_branch"...HEAD >/tmp/pr/commit_list
+
+  if [[ ! -s /tmp/pr/diff ]]; then
+    warn "No changes"
+    return
+  fi
+
+  info "==> Creating messages.json.."
+  cat </tmp/pr/diff | prp -ne gen-git-pr-message.md | llm >/tmp/pr/messages.json
+
+  info "==> Creating title/body.."
+  jq -r '.title' /tmp/pr/messages.json >/dev/null 2>&1 || {
+    # ```から始まる行を削除
+    sed -i '/^```/d' /tmp/pr/messages.json
+    # 空行を削除
+    sed -i '/^$/d' /tmp/pr/messages.json
+  }
+  jq -r '.title' /tmp/pr/messages.json >/tmp/pr/title
+  jq -r '.body' /tmp/pr/messages.json >/tmp/pr/body
+  if [[ -n $issue ]]; then
+    cat_issue >>/tmp/pr/body
+  fi
+  cat_commit_list >>/tmp/pr/body
+
+  info "==> Pushing commits.."
+  git push -u origin HEAD
+  info "==> Creating PR!.."
+  cat </tmp/pr/body | gh pr create --web --title "$(cat </tmp/pr/title)" --body-file -
+  info "==> Done!"
+}
+main "$@"

--- a/bin/pr
+++ b/bin/pr
@@ -13,10 +13,16 @@ warn() { _log yellow "$*"; }
 error() { _log red "$*" && exit 1; }
 
 end() {
-  rm -rf /tmp/pr
+  # rm -rf /tmp/pr
+  info "==> Done!"
 }
 
-find_target_branch() {
+find_target_branch_with_fetch() {
+  # Fetch the latest changes from the remote repository
+  info "==> Git fetching.."
+  git fetch origin
+
+  info "==> Finding target branch.."
   remote_branches=$(git ls-remote --heads origin)
   branches=(develop main master)
   for b in "${branches[@]}"; do
@@ -47,23 +53,16 @@ $(sed -e 's/^/- /' /tmp/pr/commit_list)
 EOF
 }
 
-main() {
-  local issue=$1
+check() {
   hass "${depends[@]}"
 
   if git branch --show-current | grep -q 'develop'; then
     error "==> You are on develop branch."
   fi
+}
 
-  # Fetch the latest changes from the remote repository
-  info "==> Git fetching.."
-  git fetch origin
-  info "==> Finding target branch.."
-  target_branch=$(find_target_branch)
-
+create_pr_parts() {
   mkdir -p /tmp/pr
-  # trap end 0 1 2 3 15
-
   info "==> Creating diff.."
   git diff "$target_branch"...HEAD >/tmp/pr/diff
   info "==> Creating commit_list.."
@@ -71,7 +70,7 @@ main() {
 
   if [[ ! -s /tmp/pr/diff ]]; then
     warn "No changes"
-    return
+    exit 0
   fi
 
   info "==> Creating messages.json.."
@@ -90,11 +89,30 @@ main() {
     cat_issue >>/tmp/pr/body
   fi
   cat_commit_list >>/tmp/pr/body
+}
 
+create_pr_with_push() {
   info "==> Pushing commits.."
   git push -u origin HEAD
   info "==> Creating PR!.."
   cat </tmp/pr/body | gh pr create --web --title "$(cat </tmp/pr/title)" --body-file -
-  info "==> Done!"
+}
+
+main() {
+  local issue=$1
+  check
+
+  trap end 0 1 2 3 15
+  target_branch=$(find_target_branch_with_fetch)
+
+  create_parts=1
+  if [[ $issue == "/tmp" ]]; then
+    create_parts=0
+  fi
+
+  if [[ $create_parts -eq 1 ]]; then
+    create_pr_parts
+  fi
+  create_pr_with_push
 }
 main "$@"

--- a/bin/pr
+++ b/bin/pr
@@ -64,7 +64,7 @@ check() {
 create_pr_parts() {
   mkdir -p /tmp/pr
   info "==> Creating diff.."
-  git diff "$target_branch"...HEAD >/tmp/pr/diff
+  git diff "$target_branch"...HEAD -- ':!*/package-lock.json' >/tmp/pr/diff
   info "==> Creating commit_list.."
   git log --oneline "$target_branch"...HEAD >/tmp/pr/commit_list
 

--- a/bin/prp
+++ b/bin/prp
@@ -41,7 +41,6 @@ get_content() {
 main() {
   initialize "$@"
   set -euo pipefail
-  content="$(get_content)" && export content
   local f
   f=$(
     fire |
@@ -50,6 +49,7 @@ main() {
         --select-1 --exit-0
   )
   [[ -z $f ]] && return 0
+  content="$(get_content)" && export content
   # trap 'rm -f "$dst"' EXIT
   cat <"$f" |
     envsubst | tee >(clip) >"$dst"


### PR DESCRIPTION
## 概要

GitHub Pull Request作成を補助する`pr`スクリプトを新規実装。また、関連する既存スクリプトに細かな修正を加える。

## 変更点

- `pr`スクリプトを新規実装。以下の機能を含む
  - リモートブランチ(`develop`, `main`, `master`)を探索し、対象ブランチとする
  - 対象ブランチとの差分、コミットリストを生成
  - 生成した差分を元にLLMを用いてPRメッセージ(タイトル/本文)を生成
  - 関連Issue、コミットリストを本文に追加
  - ローカルブランチをoriginにプッシュ
  - ghコマンドを用いてPRを作成(`--web`オプション使用)
  - `git diff`の対象から`package-lock.json`を除外
  - `develop`ブランチでの実行を防止
- `git_llm_commit`: `git diff`の対象から`package-lock.json`を除外
- `gpr`: ディレクトリ移動(`cd`)処理に`|| exit`を追加し、エラー発生時の異常終了を防止。ローカル変数宣言と代入を分離
- `lib/setup/trans/manjaro`: setup時にインストールするアプリリストに`kdeconnect`を追加
- `llm`: LLMモデルとして`gemini-2.5-flash-preview-04-17`を明示的に指定
- `prp`: `fzf`によるファイル選択の前に`get_content`を実行していたのを、選択後に移動

## コミット一覧

- d852ec8a feat(setup): manjaro: Add kdeconnect as default
- 7bc23bb9 fix(bin): Fix llm command failed if large changes exist
- 92bcadcb fix(bin): Fix pr
- f6e5aafd feat(bin): llm: Specify model 2.5 flash 4/17 preview
- 4bf40805 feat(bin): Add new pr creation command via llm
- 6abd93f2 fix(bin): Fix gpr lint error

